### PR TITLE
Add Negative State Checking for Notifications

### DIFF
--- a/MMM-homeassistant-sensors.js
+++ b/MMM-homeassistant-sensors.js
@@ -224,23 +224,47 @@ Module.register("MMM-homeassistant-sensors", {
 						var notificationValue = undefined;
 						var origValue = values[i].notificationState;
 
-						console.log("MMM-homeassistant-sensors - stateval: " + stateval);
-						var found = false;
+						if(debuglogging) {
+							console.log("MMM-homeassistant-sensors - stateval: " + stateval);
+						}
+
 						// Check conditions of sending notification
 						if(values[i].notificationConditions.length != 0) {
+							var found = false;
+
 							values[i].notificationConditions.forEach((condition) => {
+
+								var negState = false;
+
+								if(condition.negState === true) {
+									negState = true;
+								}
+
 								condition.stateVals.forEach((val) => {
-									console.log("MMM-homeassistant-sensors - vals: " + val);
+									if(debuglogging) {
+										console.log("MMM-homeassistant-sensors - vals: " + val);
+									}
+									// If sensor value matches the value we're looking for
 									if(stateval == val) {
-										console.log("MMM-homeassistant-sensors - " + val + " found");
-										notificationValue = condition.notificationVal;
+										if(debuglogging) {
+											console.log("MMM-homeassistant-sensors - " + val + " found");
+										}
 										found = true;
 									}
 								});
 
+								// If we found what we're looking for - or didn't find what we're NOT looking for
+								if((!found && negState) ||(found && !negState)) {
+									notificationValue = condition.notificationVal;
+								}
 								// Set negative value for notification if necessary
-								if(!found && condition.notificationValNeg !== undefined) {
-									console.log("MMM-homeassistant-sensors - vals not found");
+								else if(!found && !negState && condition.notificationValNeg !== undefined) {
+									if(debuglogging) {
+										console.log("MMM-homeassistant-sensors - vals not found");
+									}
+									notificationValue = condition.notificationValNeg;
+								}
+								else if(found && negState && condition.notificationValNeg !== undefined) {
 									notificationValue = condition.notificationValNeg;
 								}
 							});

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ The configuration can be very simple, from just displaying a simple value from a
 | `displaydates`       | No | `false` | If you want to show dates for last update by default. This can be turned off or on for each sensor as well.|
 | `displaytimes`       | No | `false` | If you want to show times for last update by default. This can be turned off or on for each sensor as well.|
 | `notificationOnly`   | No | `false` | Don't show any sensors, just send a notification based on notificationConditions.|
-| `notificationConditions` | No | `[]` | See section below for details. This is required to send a notification. |
 | `dateformat`         | No | `'YYYY-MM-DD'` | See [moments](https://momentjs.com/docs/#/displaying/) for more date format options.|
 | `timeformat`         | No | `'HH:mm:ss'` | See [moments](https://momentjs.com/docs/#/displaying/) for more time format options.|
 | `rowClass`           | No | `'small'` | Changing the font size, Possible values: `'small'`, `'normal'`, `'big'` <br> Default value: `'small'` |
@@ -100,11 +99,13 @@ The configuration can be very simple, from just displaying a simple value from a
 | `icons`              | `array` | Define specific icons for spesific values/states (see example below). You can use the icon names from the: [MaterialDesignIcons](https://materialdesignicons.com/).|
 | `replace`            | `array` | Define specific values/states that will be owerriden by the specified values.|
 | `notificationName`    | `string` | Name of the notification to send from this notification. Example: "Home" |
+| `notificationConditions` | `array` | See section below for details. This is required to send a notification. |
 
 ## NotificationConditions options
 | Option               | Required | Type | Description |
 | -------------------- | -------- | ---- | ----------- |
 | `stateVals` 		| Yes | `array` | What values the notification should trigger on |
+| `negState`  | `boolean` | True if you want the state to be negated. As in, looking for NOT stateVals. Default `false` |
 | `notificationVal` 	| Yes | `Any` | The value of the notification when trigger is met |
 | `notificationValNeg` 	| No | `Any` | The value of the notification when trigger is not met (optional) |
 


### PR DESCRIPTION
If you want to check for NOT a state, that is now possible.

Also updates the README to reflect the change (and fix an item being in the wrong section) and removes some noisy logging. (Only logs those lines if debuglogging is true)